### PR TITLE
Add docker-compose.yml for OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
-# README
+# elasticsearch-exercise
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Install
 
-Things you may want to cover:
+```sh
+bundle
+```
 
-* Ruby version
+## Run Rails
 
-* System dependencies
+```sh
+rails s
+```
 
-* Configuration
+## Run OpenSearch
 
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+```
+docker compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  opensearch:
+    image: opensearchproject/opensearch
+    ports:
+      - 9200:9200
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    environment:
+      discovery.type: single-node
+      plugins.security.disabled: true # 認証とSSLを無効化
+
+volumes:
+  opensearch-data:


### PR DESCRIPTION
OpenSearch をローカルで起動するための docker-compose.yml を追加しました。
curl で確認するとき面倒なので、パスワード認証とSSLは無効にしてます。

起動
```sh
docker compose up -d
```

確認
```sh
curl localhost:9200
```