### PR TITLE
OpenSearch client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "opensearch-ruby"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,11 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.12.0)
+    faraday (2.7.11)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -116,6 +121,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mutex_m (0.1.2)
     net-imap (0.4.1)
       date
@@ -133,6 +139,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
+    opensearch-ruby (3.0.1)
+      faraday (>= 1.0, < 3)
+      multi_json (>= 1.0)
     psych (5.1.0)
       stringio
     puma (6.4.0)
@@ -215,6 +224,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -223,6 +233,7 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  opensearch-ruby
   puma (>= 5.0)
   rails (~> 7.1.0)
   sprockets-rails

--- a/app/controllers/opensearch_controller.rb
+++ b/app/controllers/opensearch_controller.rb
@@ -1,0 +1,9 @@
+
+class OpensearchController < ApplicationController 
+  def index
+    client = OpenSearch::Client.new(host: 'localhost:9200')
+
+    @health = client.ping
+    @indices = client.cat.indices(format: 'json') rescue nil
+  end
+end

--- a/app/views/opensearch/index.erb
+++ b/app/views/opensearch/index.erb
@@ -1,0 +1,13 @@
+<h1>OpenSearch Health Check</h1>
+
+<section>
+  <h2>Health</h2>
+  <div><%= @health %><div>
+</section>
+
+<section>
+  <h2>Indices</h2>
+  <code>
+    <%= @indices.to_json %>
+  </code>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,5 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  get "opensearch" => "opensearch#index"
 end


### PR DESCRIPTION
elasticsearch-ruby も検証しましたが、現行の OpenSearch だと普通に互換性が無いみたいです。
なので opensearch-ruby を使うことにします。

elasticsearch-rails みたいな便利機能は無いので、OpenSearchのDSLを頑張りましょう。

簡単な動作確認ページも作りました。
http://localhost:3000/opensearch
<img width="450" alt="image" src="https://github.com/AnguillaJaponica/elasticsearch-exercise/assets/11018062/049836b3-0d07-47b1-bec7-65059aece92d">
