### PR TITLE
Create index by bulk-operations

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,17 +7,22 @@ class Product < ApplicationRecord
     client.indices.delete(index: INDEX_NAME) rescue nil
     client.indices.create(index: INDEX_NAME)
 
-    self.find_each do |product|
-      client.index(
-        index: INDEX_NAME,
-        id: product.id,
-        body: {
-          name: product.name,
-          category: product.category,
-          average_rating: product.average_rating,
-          price: product.price,
-        },
-      )
+    self.find_in_batches do |products|
+      actions = products.map do |product|
+        {
+          index: {
+            _index: INDEX_NAME,
+            _id: product.id,
+            data: {
+              name: product.name,
+              category: product.category,
+              average_rating: product.average_rating,
+              price: product.price,
+            }
+          }
+        }
+      end
+      client.bulk(body: actions)
     end
   end
 end


### PR DESCRIPTION
Bulk operations を使ってインデックス登録を高速化しました。
6s → 0.3s くらいになりました。

ref: https://opensearch.org/docs/latest/clients/ruby/#bulk-operations

OpenSearch の制限がわからなかったのと、全レコードを Hash にするのはメモリ的に厳しいかもしれないので、一旦 find_in_batches で 1000 件ずつ登録する仕様です。