### PR TITLE
Synonym

### DIFF
--- a/app/controllers/synonyms_controller.rb
+++ b/app/controllers/synonyms_controller.rb
@@ -1,0 +1,24 @@
+class SynonymsController < ApplicationController
+  def index
+    @synonyms = Synonym.all
+  end
+  
+  def create
+    synonym_params = params.require(:synonym).permit(:words)
+    ApplicationRecord.transaction do
+      Synonym.create!(synonym_params)
+      # synonymを更新するためインデックスを再生成する
+      Product.import
+    end
+    redirect_to synonyms_path
+  end
+  
+  def destroy
+    ApplicationRecord.transaction do
+      Synonym.find(params[:id]).destroy!
+      # synonymを更新するためインデックスを再生成する
+      Product.import
+    end
+    redirect_to synonyms_path
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,7 +24,7 @@ class Product < ApplicationRecord
           filter: {
             custom_synonym_filter: {
               type: "synonym",
-              synonyms: [] # TOOD: 類義語を設定できるようにする
+              synonyms: Synonym.pluck(:words)
             }
           }
         }

--- a/app/models/synonym.rb
+++ b/app/models/synonym.rb
@@ -1,0 +1,2 @@
+class Synonym < ApplicationRecord
+end

--- a/app/views/synonyms/index.html.slim
+++ b/app/views/synonyms/index.html.slim
@@ -1,0 +1,18 @@
+h1 Synonyms
+
+p
+  a[href="https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-tokenfilter.html#analysis-synonym-define-synonyms" target="_blank"] Format
+= form_with model: Synonym.new do |f|
+  = f.text_field :words, required: true, size: 40, placeholder: 'ipod, i-pod, i pod'
+  = f.submit
+
+table
+  thead
+  tbody
+    - @synonyms.each do |synonym|
+      tr
+        td = synonym.id
+        td = synonym.words
+        td
+          = form_with model: synonym, method: :delete do |f|
+            = f.submit 'Delete'

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,8 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  socket: /tmp/mysql.sock
+  # socket: /tmp/mysql.sock
+  host: 127.0.0.1
 
 development:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
   root 'products#index'
-
   get "opensearch" => "opensearch#index"
+  resources :synonyms, only: [:index, :create, :destroy]
 end

--- a/db/migrate/20231111034904_create_synonyms.rb
+++ b/db/migrate/20231111034904_create_synonyms.rb
@@ -1,0 +1,8 @@
+class CreateSynonyms < ActiveRecord::Migration[7.1]
+  def change
+    create_table :synonyms do |t|
+      t.string :words, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_17_103105) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_11_034904) do
   create_table "products", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "link", default: "", null: false
     t.float "average_rating", default: 0.0, null: false
     t.integer "price", default: 0, null: false
     t.string "category", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "synonyms", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "words", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
同義語を登録できるようにしました。

`ブドウ, マスカット` という同義語を登録すると、「ブドウ」を検索したら「マスカット」も出るようになります。
カンマ区切りだと双方向になり、片方向のみにしたいときは `ブドウ => マスカット` という形式にします。

<img width="165" alt="image" src="https://github.com/AnguillaJaponica/elasticsearch-exercise/assets/11018062/84233377-830e-46e6-b605-deadb1806101">


参考
https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-tokenfilter.html#analysis-synonym-define-synonyms